### PR TITLE
Update Rimworld Readme Docs

### DIFF
--- a/worlds/rimworld/docs/en_RimWorld.md
+++ b/worlds/rimworld/docs/en_RimWorld.md
@@ -10,13 +10,13 @@ There are several types of item in RimWorld:
     * Research is also the primary progression in the game - you need certain tech to complete your victory condition, and crafting items will also require their requisite research.
 * Boons (Coming soon...)
     * All of the fun helpful stuff people can send you!
-    * Colonists
+    * Colonists - DONE
     * Item drops
     * Merchants
     * And more!
 * Traps (Coming soon...)
     * All the fun bad stuff people can send you! 
-    * Raids
+    * Raids - DONE
     * Scaria
     * Weather Events
     * Off-map problem causers
@@ -32,12 +32,12 @@ Locations in RimWorld are all tasks to be accomplished. They come in several for
 * Crafting
     * The Archipelago Grinder is a new building in the Production tab. It will request pairs of items that the player can craft. Send the two requested items to the grinder, and it will send the location.
 * Combat (Coming soon...)
-    * Defeat raiders to obtain items that can be consumed to complete a location
+    * Defeat raiders to obtain items that can be consumed to complete a location - DONE
     * Trophies for all of the different types of enemy in the game
 * Quests (Coming soon...)
     * Quest rewards that send location checks, as alternate choices to the vanilla quest rewards
 * Trade (Coming soon...)
-    * Traveling traders and merchants at other settlements will sell items that can send locations
+    * Traveling traders and merchants at other settlements will sell items that can send locations - DONE
 
 
 ## What is the goal of this game when randomized?

--- a/worlds/rimworld/docs/setup_en.md
+++ b/worlds/rimworld/docs/setup_en.md
@@ -48,6 +48,6 @@ This mod has been designed to attempt to support future expansions as well as mo
 5. Send the ArchipelagoItemDefs.xml file to all Rimworld players in this multiworld.
 6. All players must put this ArchipelagoItemDefs.xml file in their mod folder (`Rimworld/Mods/RimworldArchipelago/Defs`) - it will overwrite the existing xml file.
 7. Open the apworld file (it's a zip file - it can be opened with anything that can open a zip file.)
-8. Replace the `ArchipelagoItemDefs.xml` in the apworld with the new xml file.
+8. Replace the `ArchipelagoItemDefs.xml` in the apworld with the new xml file.  Whoever generates the multiworld must replace this file as well, otherwise modded items and research will not appear in the multiworld as checks.
 9. If multiple people in the same multiworld are using different sets of mods, each player must exclude the items from the other mods from their yamls. (Soon, there will be a way to do this directly. As a workaround, you should be able to exclude the locations and items from other mods - you'll have to go digging through `ArchipelagoItemDefs.xml` to find them - it should include the source mod for all items.)
 10. Cross your fingers and generate as normal! If it all works and we ever meet in person, you now owe me a drink. Enjoy whatever madness you have cooked up. Also, and I hope nobody has to hear this, but just in case... research and item names will be visible to other players.


### PR DESCRIPTION
## What is this fixing or adding?
Clarifies under advanced setup for modded content that the host who generates the main world file needs to modify their rimworld.apworld archive file with the Rimworld user's export.

Also marked a few features that were already implemented as done like trading and raid traps.  Thanks for all your effort, Phantom!